### PR TITLE
Fix performance issues with system.runJob when finding a block

### DIFF
--- a/scripts/NPCs/Woodcutter.ts
+++ b/scripts/NPCs/Woodcutter.ts
@@ -982,8 +982,8 @@ export default class Woodcutter extends NPC{
                     blockToReturn = block;
                     break;
                 }
-                yield;
             }
+            yield;
         }
 
         return promiseResolve(blockToReturn);


### PR DESCRIPTION
The loop was only yielding when the inner iterator found a block - but we need to yield even when the inner iterator returns null.